### PR TITLE
Added "Be Right back" to NodeBB user's status dropdown loist

### DIFF
--- a/public/language/en-GB/global.json
+++ b/public/language/en-GB/global.json
@@ -112,6 +112,7 @@
 	"away": "Away",
 	"dnd": "Do not disturb",
 	"invisible": "Invisible",
+	"berightback": "Be right back",
 	"offline": "Offline",
 
 	"email": "Email",

--- a/public/language/en-US/global.json
+++ b/public/language/en-US/global.json
@@ -91,6 +91,7 @@
     "away": "Away",
     "dnd": "Do not disturb",
     "invisible": "Invisible",
+    "berightback": "Be right back",
     "offline": "Offline",
     "email": "Email",
     "language": "Language",

--- a/src/socket.io/user/status.js
+++ b/src/socket.io/user/status.js
@@ -17,7 +17,7 @@ module.exports = function (SocketUser) {
             throw new Error('[[error:invalid-uid]]');
         }
 
-        const allowedStatus = ['online', 'offline', 'dnd', 'away'];
+        const allowedStatus = ['online', 'berightback', 'offline', 'dnd', 'away'];
         if (!allowedStatus.includes(status)) {
             throw new Error('[[error:invalid-user-status]]');
         }

--- a/themes/nodebb-theme-persona/less/persona.less
+++ b/themes/nodebb-theme-persona/less/persona.less
@@ -47,3 +47,4 @@
 @material-info:            #717484;
 @material-warning:         #ff6d00;
 @material-danger:          #F44336;
+@material-default:         #33b5e5;

--- a/themes/nodebb-theme-persona/less/style.less
+++ b/themes/nodebb-theme-persona/less/style.less
@@ -85,6 +85,10 @@ a:hover, .btn-link:hover, .btn-link:active, .btn-link:focus {
 	&.offline {
 		color: @gray;
 	}
+
+	&.berightback {
+		color: @material-default;
+	}
 }
 
 

--- a/themes/nodebb-theme-persona/templates/partials/menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/menu.tpl
@@ -108,6 +108,11 @@
                                 </a>
                             </li>
                             <li>
+                                <a href="#" class="user-status" data-status="berightback">
+                                    <i class="fa fa-fw fa-circle status berightback"></i><span <!-- IF user.berightback -->class="bold"<!-- ENDIF user.berightback -->> [[global:berightback]]</span>
+                                </a>
+                            </li>
+                            <li>
                                 <a href="#" class="user-status" data-status="away">
                                     <i class="fa fa-fw fa-circle status away"></i><span <!-- IF user.away -->class="bold"<!-- ENDIF user.away -->> [[global:away]]</span>
                                 </a>


### PR DESCRIPTION
Made the following changes to add a new status called "Be right back" for students in the dropdown:

**Changes**
1. modified src/socket.io/user/status.js to include "berightback" as an allowedStatus
2. created a new material color variable to assign the new status to in themes/nodebb-theme-persona/less/persona.less
3. created a new css class assigning "berightback" to in themes/nodebb-theme-persona/less/persona.less
4. created the physical status with the newly created color and css styling in themes/nodebb-theme-persona/less/persona.less

**Effects** 
resolves #5 

**Testing** 
Manually verified visually that the new status appeared in the dropdown, and became bolded when selected in the dropdown as well. 

`npm run lint` and `npm run test` both pass like before