### PR TITLE
Added testing in test/messaging.js for be right back status

### DIFF
--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -60,6 +60,7 @@ MessageObject:
           enum:
             - online
             - offline
+            - berightback
             - dnd
             - away
         banned:

--- a/public/openapi/components/schemas/UserObject.yaml
+++ b/public/openapi/components/schemas/UserObject.yaml
@@ -108,6 +108,7 @@ UserObject:
         - online
         - offline
         - dnd
+        - berightback
         - away
       example: online
     flags:
@@ -302,6 +303,7 @@ UserObjectFull:
         - online
         - offline
         - dnd
+        - berightback
         - away
       example: online
     flags:
@@ -532,6 +534,7 @@ UserObjectSlim:
         - online
         - offline
         - dnd
+        - berightback
         - away
       example: online
     postcount:

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -41,6 +41,11 @@ SocketModules.chats.isDnD = async function (socket, uid) {
     return status === 'dnd';
 };
 
+SocketModules.chats.isBRB = async function (socket, uid) {
+    const status = await db.getObjectField(`user:${uid}`, 'status');
+    return status === 'berightback';
+};
+
 SocketModules.chats.newRoom = async function (socket, data) {
     sockets.warnDeprecated(socket, 'POST /api/v3/chats');
 

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -539,6 +539,17 @@ describe('Messaging Library', () => {
             });
         });
 
+        it('should return true if user is be right back', (done) => {
+            db.setObjectField(`user:${mocks.users.herp.uid}`, 'status', 'berightback', (err) => {
+                assert.ifError(err);
+                socketModules.chats.isBRB({ uid: mocks.users.foo.uid }, mocks.users.herp.uid, (err, isBRB) => {
+                    assert.ifError(err);
+                    assert(isBRB);
+                    done();
+                });
+            });
+        });
+
         it('should fail to load recent chats with invalid data', (done) => {
             socketModules.chats.getRecentChats({ uid: mocks.users.foo.uid }, null, (err) => {
                 assert.equal(err.message, '[[error:invalid-data]]');


### PR DESCRIPTION
Made the following changes to add test the "be right back" status:

**Changes**
- modified test/messaging.js to include a socketModules check for "be right back"
- modified src/socket.io/modules.js to check that "be right back" could be created
- modified the UserObject and Chat schema to allow for testing to work as desired (public/openapi/components/schemas/UserObject.yaml and public/openapi/components/schemas/Chats.yaml)

**Effects** 
tests #7

**Testing** 
Manually verified that the tests added to the test/messaging.js passed.

Confirmed that` npm run lint `and `npm run test` still pass like before.